### PR TITLE
Fix GitHub URL on FAQ page

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -208,7 +208,7 @@
             <div class="faq-title">How can I contribute to the initiative?</div>
             <p class="faq-text">We welcome feedback. Please leave your questions, comments, or concerns on <a href="http://goo.gl/forms/RW7GJOE61GsRACIh2" target="_blank">this form here</a>. MapSwipe is an open source project created and maintained by volunteers like you, so the best way to see new features implemented is to get involved and make it happen.
               <br>
-              <br>More technical feedback can be added to <a href="#">https://github.com/mapswipe</a>
+              <br>More technical feedback can be added to <a href="https://github.com/mapswipe">https://github.com/mapswipe</a>
             </p>
           </div>
         </div>


### PR DESCRIPTION
Hi there,

Not sure how open you are to pull requests.

Found out about MapSwipe earlier today via [Twitter](https://twitter.com/osm_be/status/753959061796843520) and started playing with the app on iOS. It works but there still seem some quirks to iron out.

Looking through the [FAQ page](http://mapswipe.org/faq.html) I found a link to the GitHub repos which doesn't work as it points to `#` instead of the link the text says it should point to (`https://github.com/mapswipe`). Took me 2 seconds to fix so might as well open a pull request. 

Feel free to close if you are not looking for pull requests.