### PR TITLE
Add a first pass attempt to a KML validator

### DIFF
--- a/import.html
+++ b/import.html
@@ -46,6 +46,19 @@
             databaseURL: "https://msf-mapswipe.firebaseio.com",
             storageBucket: "msf-mapswipe.appspot.com",
         };
+
+        function validateKML(kmlString) {
+            var parser = new DOMParser();
+            try {
+                var doc = parser.parseFromString(kmlString, 'text/xml');
+                return true;
+            }
+            catch (e) {
+                console.log(e);
+                return false;
+            }
+        }
+
         firebase.initializeApp(config);
 
         firebase.auth().signInAnonymously().catch(function(error) {
@@ -81,6 +94,9 @@
                 return;
             } else if(kml.length <= 3) {
                 alert("KML not entered");
+                return;
+            } else if(!validateKML(kml)) {
+                alert("Entered KML is invalid, try re-exporting it or re-pasting it");
                 return;
             } else if(image.length <= 3 || image.indexOf(".jpg") == -1 && image.indexOf(".png") === -1 && image.indexOf(".jpeg") === -1) {
                 alert("Make sure your image link ends with .jpg, .jpg, or .jpeg");

--- a/import.html
+++ b/import.html
@@ -50,7 +50,15 @@
         function validateKML(kmlString) {
             var parser = new DOMParser();
             try {
+                // Handle the case where the XML is invalid with either an
+                // exception or returned error element
                 var doc = parser.parseFromString(kmlString, 'text/xml');
+
+                // https://developer.mozilla.org/en-US/docs/Web/API/DOMParser#Parsing_XML
+                if (doc.children[0].tagName === 'parsererror'){
+                    return false;
+                }
+                // Otherwise, return true
                 return true;
             }
             catch (e) {
@@ -96,7 +104,7 @@
                 alert("KML not entered");
                 return;
             } else if(!validateKML(kml)) {
-                alert("Entered KML is invalid, try re-exporting it or re-pasting it");
+                alert("Entered KML is invalid, try re-exporting or re-pasting it");
                 return;
             } else if(image.length <= 3 || image.indexOf(".jpg") == -1 && image.indexOf(".png") === -1 && image.indexOf(".jpeg") === -1) {
                 alert("Make sure your image link ends with .jpg, .jpg, or .jpeg");


### PR DESCRIPTION
This is a simple implementation to try to validate the pasted KML as valid XML.
A more sophisticated parser (like https://github.com/mapbox/togeojson) would
attempt to validate the XML as a KML document.